### PR TITLE
Eventdelete

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
 
   def index
-    @events = Event.all
+    @events = Event.where(created_at: 1.hours.ago..Time.now)
     @hash = Gmaps4rails.build_markers(@events) do |event, marker|
       marker.lat event.latitude
       marker.lng event.longitude
@@ -83,7 +83,7 @@ class EventsController < ApplicationController
       format.js { render :layout => false }
 
       @event.liked_by current_user
-    
+
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,9 @@
 class EventsController < ApplicationController
 
   def index
-    @events = Event.where(created_at: 1.hours.ago..Time.now)
+    # Filters out events that were created longer than 365 days ago;
+    # can be changed to e.g. 1 hour ago by changing 365.days.ago to 1.hours.ago
+    @events = Event.where(created_at: 365.days.ago..Time.now)
     @hash = Gmaps4rails.build_markers(@events) do |event, marker|
       marker.lat event.latitude
       marker.lng event.longitude


### PR DESCRIPTION
Does not delete any events, just filters them out according to a specified time-frame, which is presently set to one year.